### PR TITLE
S3: Copy files s3->s3, optinally unpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,24 @@ Optional parameters:
 - `StackParam_Key` - Will pass value of this param down to stack's `Key` parameter
 - `OnFailure` - Behaviour on stack creation failure. Accepted values are `DO_NOTHING`,`ROLLBACK` and `DELETE`
 
+### Copy or unpack objects between S3 buckets
+
+This custom resource allows copying from source to destination s3 buckets. For source, if you provide prefix
+(without trailing slash), all objects under that prefix will be copied. Alternatively, if you provide s3 object
+with `*.zip` extensions, this object will be unpacked before it's files are unpacked to target bucket / prefix. 
+Please note that this lambda function design does not include recursive calls if lambda is timing out, thus it does not 
+permit mass file unpacking, but is rather designed for deployment of smaller files, such as client side web applications.
+
+handler: `src/s3-copy/handler.lambda_handler`
+runtime:  `python3.6`
+
+Required parameters:
+
+- `Source` - Source object/prefix/zip-file in `s3://bucket-name/path/to/prefix/or/object.zip` format
+- `Destination` - Destination bucket and prefix in `s3://bucket-name/destination-prefix` format
+
+No optional parameters. 
+
+
 
 

--- a/src/s3-copy/__init__.py
+++ b/src/s3-copy/__init__.py
@@ -1,0 +1,1 @@
+# package marker

--- a/src/s3-copy/cr_response.py
+++ b/src/s3-copy/cr_response.py
@@ -1,0 +1,55 @@
+import logging
+from urllib.request import urlopen, Request, HTTPError, URLError
+import json
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class CustomResourceResponse:
+    def __init__(self, request_payload):
+        self.payload = request_payload
+        self.response = {
+            "StackId": request_payload["StackId"],
+            "RequestId": request_payload["RequestId"],
+            "LogicalResourceId": request_payload["LogicalResourceId"],
+            "Status": 'SUCCESS',
+        }
+        
+    def respond_error(self, message):
+        self.response['Status'] = 'FAILED'
+        self.response['Reason'] = message
+        self.respond()
+    
+    def respond(self):
+        event = self.payload
+        response = self.response
+        ####
+        #### copied from https://github.com/ryansb/cfn-wrapper-python/blob/master/cfn_resource.py
+        ####
+        
+        if event.get("PhysicalResourceId", False):
+            response["PhysicalResourceId"] = event["PhysicalResourceId"]
+        
+        logger.debug("Received %s request with event: %s" % (event['RequestType'], json.dumps(event)))
+        
+        serialized = json.dumps(response)
+        logger.info(f"Responding to {event['RequestType']} request with: {serialized}")
+        
+        req_data = serialized.encode('utf-8')
+        
+        req = Request(
+            event['ResponseURL'],
+            data=req_data,
+            headers={'Content-Length': len(req_data),'Content-Type': ''}
+        )
+        req.get_method = lambda: 'PUT'
+        
+        try:
+            urlopen(req)
+            logger.debug("Request to CFN API succeeded, nothing to do here")
+        except HTTPError as e:
+            logger.error("Callback to CFN API failed with status %d" % e.code)
+            logger.error("Response: %s" % e.reason)
+        except URLError as e:
+            logger.error("Failed to reach the server - %s" % e.reason)

--- a/src/s3-copy/handler.py
+++ b/src/s3-copy/handler.py
@@ -1,0 +1,63 @@
+import sys
+import os
+import re
+
+sys.path.append(f"{os.environ['LAMBDA_TASK_ROOT']}/lib")
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+
+import cr_response
+import logic
+
+
+def lambda_handler(event, context):
+    lambda_response = cr_response.CustomResourceResponse(event)
+    cr_params = event['ResourceProperties']
+    
+    # Validate input
+    for key in ['Source', 'Destination']:
+        if key not in cr_params:
+            lambda_response.respond_error(f"{key} property missing")
+            return
+    
+    # Validate input params format
+    src_param = cr_params['Source']
+    dst_param = cr_params['Destination']
+    src_param_match = re.match(r's3:\/\/(.*?)\/(.*)', src_param)
+    dst_param_match = re.match(r's3:\/\/(.*?)\/(.*)', dst_param)
+    
+    if src_param_match is None or dst_param_match is None:
+        lambda_response.respond_error(f"Source/Destination must be in s3://bucket/key format")
+        return
+    
+    # get prefixes
+    src_prefix = src_param_match.group(2)
+    dst_prefix = dst_param_match.group(2)
+    
+    dst = {'Bucket': dst_param_match.group(1), 'Prefix': dst_prefix}
+    
+    if event['RequestType'] == 'Delete':
+        logic.S3CopyLogic(context, type='clean', src=None, dst=dst).clean_destination()
+        lambda_response.respond()
+        return
+    
+    # if create request, generate physical id, both for create/update copy files
+    if event['RequestType'] == 'Create':
+        event['PhysicalResourceId'] = dst_param
+    
+    # check if source is prefix - than it is sync type
+    if src_prefix.endswith('/'):
+        src = {'Bucket': src_param_match.group(1), 'Prefix': src_prefix}
+        logic.S3CopyLogic(context, type='sync', src=src, dst=dst).copy()
+        lambda_response.respond()
+    # if prefix ends with zip, we need to unpack file first
+    elif src_prefix.endswith('.zip'):
+        src = {'Bucket': src_param_match.group(1), 'Key': src_prefix}
+        logic.S3CopyLogic(context, type='object-zip', src=src, dst=dst).copy()
+        lambda_response.respond()
+    # by default consider prefix as key - regular s3 object
+    else:
+        src = {'Bucket': src_param_match.group(1), 'Key': src_prefix}
+        logic.S3CopyLogic(context, type='object', src=src, dst=dst).copy()
+        lambda_response.respond()
+    
+    return 'OK'

--- a/src/s3-copy/logic.py
+++ b/src/s3-copy/logic.py
@@ -1,0 +1,114 @@
+import boto3
+import os
+import zipfile
+import glob
+import logging
+import shutil
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class S3CopyLogic:
+    ### src - dict with Bucket and Key elements
+    ### destination - dict with Bucket and Key elements
+    ###
+    def __init__(self, context, type, src, dst):
+        self.context = context
+        self.type = type
+        self.src = src
+        self.dst = dst
+        self.local_filename = None
+        self.local_download_path = f"/tmp/cache/{self.context.aws_request_id}"
+        self.local_prefix_unzip = f"/tmp/cache/{self.context.aws_request_id}/unpacked"
+        self.local_prefix = f"/tmp/cache/{self.context.aws_request_id}/upload"
+    
+    def copy(self):
+        shutil.rmtree(self.local_download_path, ignore_errors=True)
+        
+        if self.type == 'object-zip':
+            self.download_object_unpack_zip_upload()
+        elif self.type == 'object':
+            self.download_object_upload()
+        elif self.type == 'sync':
+            self.download_prefix_upload_prefix()
+        else:
+            raise f"{self.type} type not supported"
+    
+    def clean_destination(self):
+        client = boto3.client('s3')
+        bucket = boto3.resource('s3').Bucket(self.dst['Bucket'])
+        resp = client.list_objects_v2(Bucket=self.dst['Bucket'], Prefix=self.dst['Prefix'])
+        logger.info(resp)
+        if resp['KeyCount'] > 0:
+            # delete api allow deletion of multiple objects in single call
+            bucket.delete_objects(Delete={'Objects': list(map(lambda x: {'Key': x['Key']}, resp['Contents']))})
+            
+            while resp['IsTruncated']:
+                resp = client.list_objects_v2(Bucket=self.dst['Bucket'],
+                                              Prefix=self.dst['Prefix'],
+                                              ContinuationToken=resp['NextContinuationToken'])
+                bucket.delete_objects(Delete={'Objects': list(map(lambda x: {'Key': x['Key']}, resp['Contents']))})
+    
+    def download_object_unpack_zip_upload(self):
+        self.download_object()
+        self.unpack_zip()
+        self.upload(self.local_prefix_unzip)
+    
+    def download_object_upload(self):
+        self.download_object()
+        self.upload(self.local_download_path)
+    
+    def download_prefix_upload_prefix(self):
+        self.download_prefix()
+        self.upload(self.local_download_path)
+    
+    # Download whole bucket prefix
+    def download_prefix(self):
+        client = boto3.client('s3')
+        bucket = boto3.resource('s3').Bucket(self.src['Bucket'])
+        objects = []
+        resp = client.list_objects_v2(Bucket=self.src['Bucket'], Prefix=self.src['Prefix'])
+        objects += map(lambda x: x['Key'], resp['Contents'])
+        while resp['IsTruncated']:
+            resp = client.list_objects_v2(Bucket=self.src['Bucket'],
+                                          Prefix=self.src['Prefix'],
+                                          ContinuationToken=resp['NextContinuationToken'])
+            objects += map(lambda x: x['Key'], resp['Contents'])
+        
+        for object in objects:
+            local_path = self.local_download_path + "/"
+            local_path += object.replace(self.src['Prefix'], '')
+            logger.info(f"s3://{self.src['Bucket']}/{object} -> {local_path}")
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
+            bucket.download_file(object, local_path)
+    
+    # Download S3 object to lambda /tmp under current request
+    def download_object(self):
+        local_filename = os.path.basename(self.src['Key'])
+        self.local_filename = f"{self.local_download_path}/{local_filename}"
+        os.makedirs(os.path.dirname(self.local_filename), exist_ok=True)
+        s3 = boto3.resource('s3')
+        logger.info(f"s3://{self.src['Bucket']}/{self.src['Key']} -> {self.local_filename}")
+        s3.Bucket(self.src['Bucket']).download_file(self.src['Key'], self.local_filename)
+    
+    # Unpack downloaded zip archive
+    def unpack_zip(self):
+        os.makedirs(os.path.dirname(self.local_prefix_unzip), exist_ok=True)
+        logger.info(f"Unpack {self.local_filename} to {self.local_prefix_unzip}")
+        zip_ref = zipfile.ZipFile(self.local_filename, 'r')
+        zip_ref.extractall(self.local_prefix_unzip)
+        zip_ref.close()
+    
+    # Upload files to destination
+    def upload(self, path):
+        bucket = boto3.resource('s3').Bucket(self.dst['Bucket'])
+        logger.info(f"Uploading from {path}")
+        for local_path in glob.glob(f"{path}/**/*", recursive=True):
+            if not os.path.isdir(local_path):
+                destination_key = self.dst['Prefix']
+                if not destination_key[-1] == '/':
+                    destination_key += '/'
+                destination_key += local_path.replace(f"{path}/", '')
+                logger.info(f"{local_path} -> s3://{self.dst['Bucket']}/{destination_key}")
+                bucket.upload_file(local_path, destination_key)


### PR DESCRIPTION
### Copy or unpack objects between S3 buckets

This custom resource allows copying from source to destination s3 buckets. For source, if you provide prefix
(without trailing slash), all objects under that prefix will be copied. Alternatively, if you provide s3 object
with `*.zip` extensions, this object will be unpacked before it's files are unpacked to target bucket / prefix. 
Please note that this lambda function design does not include recursive calls if lambda is timing out, thus it does not 
permit mass file unpacking, but is rather designed for deployment of smaller files, such as client side web applications.

handler: `src/s3-copy/handler.lambda_handler`
runtime:  `python3.6`

Required parameters:

- `Source` - Source object/prefix/zip-file in `s3://bucket-name/path/to/prefix/or/object.zip` format
- `Destination` - Destination bucket and prefix in `s3://bucket-name/destination-prefix` format

No optional parameters. 

